### PR TITLE
Change service/var names to prod/nonprod/critical

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,22 +38,22 @@ No modules.
 | Name | Type |
 |------|------|
 | [pagerduty_business_service.workload](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/business_service) | resource |
-| [pagerduty_extension.alerts](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/extension) | resource |
 | [pagerduty_extension.critical](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/extension) | resource |
-| [pagerduty_extension.notifications](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/extension) | resource |
-| [pagerduty_service.alerts](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service) | resource |
+| [pagerduty_extension.nonprod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/extension) | resource |
+| [pagerduty_extension.prod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/extension) | resource |
 | [pagerduty_service.critical](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service) | resource |
-| [pagerduty_service.notifications](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service) | resource |
-| [pagerduty_service_dependency.alerts](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency) | resource |
+| [pagerduty_service.nonprod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service) | resource |
+| [pagerduty_service.prod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service) | resource |
 | [pagerduty_service_dependency.critical](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency) | resource |
-| [pagerduty_service_dependency.notifications](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency) | resource |
+| [pagerduty_service_dependency.nonprod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency) | resource |
+| [pagerduty_service_dependency.prod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency) | resource |
 | [pagerduty_service_dependency.workload](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency) | resource |
-| [pagerduty_service_integration.alerts](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration) | resource |
 | [pagerduty_service_integration.critical](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration) | resource |
-| [pagerduty_service_integration.notifications](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration) | resource |
-| [pagerduty_slack_connection.alerts](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/slack_connection) | resource |
+| [pagerduty_service_integration.nonprod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration) | resource |
+| [pagerduty_service_integration.prod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration) | resource |
 | [pagerduty_slack_connection.critical](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/slack_connection) | resource |
-| [pagerduty_slack_connection.notifications](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/slack_connection) | resource |
+| [pagerduty_slack_connection.nonprod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/slack_connection) | resource |
+| [pagerduty_slack_connection.prod](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/slack_connection) | resource |
 | [pagerduty_business_service.customer](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/business_service) | data source |
 | [pagerduty_escalation_policy.engineering](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/escalation_policy) | data source |
 | [pagerduty_extension_schema.jira](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/extension_schema) | data source |
@@ -65,9 +65,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_customer_name"></a> [customer\_name](#input\_customer\_name) | Customer Name | `string` | n/a | yes |
-| <a name="input_slack_engineering_alerts_channel"></a> [slack\_engineering\_alerts\_channel](#input\_slack\_engineering\_alerts\_channel) | The Slack channel ID for engineering alerts | `string` | n/a | yes |
-| <a name="input_slack_engineering_critical_alerts_channel"></a> [slack\_engineering\_critical\_alerts\_channel](#input\_slack\_engineering\_critical\_alerts\_channel) | The Slack channel ID for engineering critical alerts | `string` | n/a | yes |
-| <a name="input_slack_engineering_notifications_channel"></a> [slack\_engineering\_notifications\_channel](#input\_slack\_engineering\_notifications\_channel) | The Slack channel ID for engineering notifications | `string` | n/a | yes |
+| <a name="input_slack_engineering_critical_channel"></a> [slack\_engineering\_critical\_channel](#input\_slack\_engineering\_critical\_channel) | The Slack channel ID for critical engineering alerts | `string` | n/a | yes |
+| <a name="input_slack_engineering_nonprod_channel"></a> [slack\_engineering\_nonprod\_channel](#input\_slack\_engineering\_nonprod\_channel) | The Slack channel ID for non-prod engineering alerts | `string` | n/a | yes |
+| <a name="input_slack_engineering_prod_channel"></a> [slack\_engineering\_prod\_channel](#input\_slack\_engineering\_prod\_channel) | The Slack channel ID for prod engineering alerts | `string` | n/a | yes |
 | <a name="input_slack_workspace_id"></a> [slack\_workspace\_id](#input\_slack\_workspace\_id) | The Slack workspace ID | `string` | n/a | yes |
 | <a name="input_workload_name"></a> [workload\_name](#input\_workload\_name) | Workload Name | `string` | n/a | yes |
 
@@ -75,18 +75,18 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_alerts_datadog_integration_key"></a> [alerts\_datadog\_integration\_key](#output\_alerts\_datadog\_integration\_key) | PagerDuty Datadog Integration for alerts |
+| <a name="output_alerts_datadog_integration_key"></a> [alerts\_datadog\_integration\_key](#output\_alerts\_datadog\_integration\_key) | PagerDuty Datadog Integration for prod alerts |
 | <a name="output_alerts_datadog_mention"></a> [alerts\_datadog\_mention](#output\_alerts\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
-| <a name="output_alerts_service_id"></a> [alerts\_service\_id](#output\_alerts\_service\_id) | PagerDuty service ID for alerts |
-| <a name="output_alerts_service_name"></a> [alerts\_service\_name](#output\_alerts\_service\_name) | PagerDuty service name for alerts |
+| <a name="output_alerts_service_id"></a> [alerts\_service\_id](#output\_alerts\_service\_id) | PagerDuty service ID for prod alerts |
+| <a name="output_alerts_service_name"></a> [alerts\_service\_name](#output\_alerts\_service\_name) | PagerDuty service name for prod alerts |
 | <a name="output_critical_datadog_integration_key"></a> [critical\_datadog\_integration\_key](#output\_critical\_datadog\_integration\_key) | PagerDuty Datadog Integration for critiacl alerts |
 | <a name="output_critical_datadog_mention"></a> [critical\_datadog\_mention](#output\_critical\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
 | <a name="output_critical_service_id"></a> [critical\_service\_id](#output\_critical\_service\_id) | PagerDuty service ID for critical alerts |
 | <a name="output_critical_service_name"></a> [critical\_service\_name](#output\_critical\_service\_name) | PagerDuty service name for critical alerts |
 | <a name="output_datadog_integrations"></a> [datadog\_integrations](#output\_datadog\_integrations) | All PagerDuty Datadog integrations |
+| <a name="output_nonprod_datadog_integration_key"></a> [nonprod\_datadog\_integration\_key](#output\_nonprod\_datadog\_integration\_key) | PagerDuty Datadog Integration for nonprod |
+| <a name="output_nonprod_service_id"></a> [nonprod\_service\_id](#output\_nonprod\_service\_id) | PagerDuty service ID for non-prod alerts |
+| <a name="output_nonprod_service_name"></a> [nonprod\_service\_name](#output\_nonprod\_service\_name) | PagerDuty service name for non-prod alerts |
 | <a name="output_notification_datadog_mention"></a> [notification\_datadog\_mention](#output\_notification\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
-| <a name="output_notifications_datadog_integration_key"></a> [notifications\_datadog\_integration\_key](#output\_notifications\_datadog\_integration\_key) | PagerDuty Datadog Integration for notifications |
-| <a name="output_notifications_service_id"></a> [notifications\_service\_id](#output\_notifications\_service\_id) | PagerDuty service ID for notifications |
-| <a name="output_notifications_service_name"></a> [notifications\_service\_name](#output\_notifications\_service\_name) | PagerDuty service name for notifications |
 | <a name="output_pagerduty_services"></a> [pagerduty\_services](#output\_pagerduty\_services) | All PagerDuty services |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -75,18 +75,18 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_alerts_datadog_integration_key"></a> [alerts\_datadog\_integration\_key](#output\_alerts\_datadog\_integration\_key) | PagerDuty Datadog Integration for prod alerts |
-| <a name="output_alerts_datadog_mention"></a> [alerts\_datadog\_mention](#output\_alerts\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
-| <a name="output_alerts_service_id"></a> [alerts\_service\_id](#output\_alerts\_service\_id) | PagerDuty service ID for prod alerts |
-| <a name="output_alerts_service_name"></a> [alerts\_service\_name](#output\_alerts\_service\_name) | PagerDuty service name for prod alerts |
 | <a name="output_critical_datadog_integration_key"></a> [critical\_datadog\_integration\_key](#output\_critical\_datadog\_integration\_key) | PagerDuty Datadog Integration for critiacl alerts |
 | <a name="output_critical_datadog_mention"></a> [critical\_datadog\_mention](#output\_critical\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
 | <a name="output_critical_service_id"></a> [critical\_service\_id](#output\_critical\_service\_id) | PagerDuty service ID for critical alerts |
 | <a name="output_critical_service_name"></a> [critical\_service\_name](#output\_critical\_service\_name) | PagerDuty service name for critical alerts |
 | <a name="output_datadog_integrations"></a> [datadog\_integrations](#output\_datadog\_integrations) | All PagerDuty Datadog integrations |
 | <a name="output_nonprod_datadog_integration_key"></a> [nonprod\_datadog\_integration\_key](#output\_nonprod\_datadog\_integration\_key) | PagerDuty Datadog Integration for nonprod |
+| <a name="output_nonprod_datadog_mention"></a> [nonprod\_datadog\_mention](#output\_nonprod\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
 | <a name="output_nonprod_service_id"></a> [nonprod\_service\_id](#output\_nonprod\_service\_id) | PagerDuty service ID for non-prod alerts |
 | <a name="output_nonprod_service_name"></a> [nonprod\_service\_name](#output\_nonprod\_service\_name) | PagerDuty service name for non-prod alerts |
-| <a name="output_notification_datadog_mention"></a> [notification\_datadog\_mention](#output\_notification\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
 | <a name="output_pagerduty_services"></a> [pagerduty\_services](#output\_pagerduty\_services) | All PagerDuty services |
+| <a name="output_prod_datadog_integration_key"></a> [prod\_datadog\_integration\_key](#output\_prod\_datadog\_integration\_key) | PagerDuty Datadog Integration for prod alerts |
+| <a name="output_prod_datadog_mention"></a> [prod\_datadog\_mention](#output\_prod\_datadog\_mention) | PagerDuty Service Mention with proper formatting |
+| <a name="output_prod_service_id"></a> [prod\_service\_id](#output\_prod\_service\_id) | PagerDuty service ID for prod alerts |
+| <a name="output_prod_service_name"></a> [prod\_service\_name](#output\_prod\_service\_name) | PagerDuty service name for prod alerts |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/critical.tf
+++ b/critical.tf
@@ -1,5 +1,5 @@
 resource "pagerduty_service" "critical" {
-  name                    = "${var.workload_name} Critical Alerts (${var.customer_name})"
+  name                    = "${var.workload_name} Alerts - Critical 24x7 (${var.customer_name})"
   acknowledgement_timeout = 7200
   alert_creation          = "create_alerts_and_incidents"
   auto_resolve_timeout    = 86400
@@ -25,7 +25,7 @@ resource "pagerduty_service_dependency" "critical" {
 }
 
 resource "pagerduty_slack_connection" "critical" {
-  channel_id        = var.slack_engineering_critical_alerts_channel
+  channel_id        = var.slack_engineering_critical_channel
   notification_type = "responder"
   source_id         = pagerduty_service.critical.id
   source_type       = "service_reference"

--- a/nonprod.tf
+++ b/nonprod.tf
@@ -1,5 +1,5 @@
-resource "pagerduty_service" "notifications" {
-  name                    = "${var.workload_name} Notifications (${var.customer_name})"
+resource "pagerduty_service" "nonprod" {
+  name                    = "${var.workload_name} Alerts - Non-Prod (${var.customer_name})"
   acknowledgement_timeout = 7200
   alert_creation          = "create_alerts_and_incidents"
   auto_resolve_timeout    = 86400
@@ -11,23 +11,23 @@ resource "pagerduty_service" "notifications" {
   }
 }
 
-resource "pagerduty_service_dependency" "notifications" {
+resource "pagerduty_service_dependency" "nonprod" {
   dependency {
     dependent_service {
       id   = pagerduty_business_service.workload.id
       type = pagerduty_business_service.workload.type
     }
     supporting_service {
-      id   = pagerduty_service.notifications.id
-      type = pagerduty_service.notifications.type
+      id   = pagerduty_service.nonprod.id
+      type = pagerduty_service.nonprod.type
     }
   }
 }
 
-resource "pagerduty_slack_connection" "notifications" {
-  channel_id        = var.slack_engineering_notifications_channel
+resource "pagerduty_slack_connection" "nonprod" {
+  channel_id        = var.slack_engineering_nonprod_channel
   notification_type = "responder"
-  source_id         = pagerduty_service.notifications.id
+  source_id         = pagerduty_service.nonprod.id
   source_type       = "service_reference"
   workspace_id      = var.slack_workspace_id
 
@@ -50,15 +50,15 @@ resource "pagerduty_slack_connection" "notifications" {
   }
 }
 
-resource "pagerduty_service_integration" "notifications" {
+resource "pagerduty_service_integration" "nonprod" {
   name    = data.pagerduty_vendor.datadog.name
-  service = pagerduty_service.notifications.id
+  service = pagerduty_service.nonprod.id
   vendor  = data.pagerduty_vendor.datadog.id
 }
 
-resource "pagerduty_extension" "notifications" {
-  name              = "jira-${pagerduty_service.notifications.id}"
+resource "pagerduty_extension" "nonprod" {
+  name              = "jira-${pagerduty_service.nonprod.id}"
   config            = templatefile("${path.module}/jira.json", {})
-  extension_objects = [pagerduty_service.notifications.id]
+  extension_objects = [pagerduty_service.nonprod.id]
   extension_schema  = data.pagerduty_extension_schema.jira.id
 }

--- a/output.tf
+++ b/output.tf
@@ -1,19 +1,19 @@
-output "alerts_datadog_integration_key" {
+output "prod_datadog_integration_key" {
   description = "PagerDuty Datadog Integration for prod alerts"
   value       = pagerduty_service_integration.prod.integration_key
 }
 
-output "alerts_datadog_mention" {
+output "prod_datadog_mention" {
   description = "PagerDuty Service Mention with proper formatting"
   value       = "@pagerduty-${replace(pagerduty_service.prod.name, "/[\\[\\]\\(\\) ]/", "")}"
 }
 
-output "alerts_service_id" {
+output "prod_service_id" {
   description = "PagerDuty service ID for prod alerts"
   value       = pagerduty_service.prod.id
 }
 
-output "alerts_service_name" {
+output "prod_service_name" {
   description = "PagerDuty service name for prod alerts"
   value       = pagerduty_service.prod.name
 }
@@ -43,7 +43,7 @@ output "nonprod_datadog_integration_key" {
   value       = pagerduty_service_integration.nonprod.integration_key
 }
 
-output "notification_datadog_mention" {
+output "nonprod_datadog_mention" {
   description = "PagerDuty Service Mention with proper formatting"
   value       = "@pagerduty-${replace(pagerduty_service.nonprod.name, "/[\\[\\]\\(\\) ]/", "")}"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,21 +1,21 @@
 output "alerts_datadog_integration_key" {
-  description = "PagerDuty Datadog Integration for alerts"
-  value       = pagerduty_service_integration.alerts.integration_key
+  description = "PagerDuty Datadog Integration for prod alerts"
+  value       = pagerduty_service_integration.prod.integration_key
 }
 
 output "alerts_datadog_mention" {
   description = "PagerDuty Service Mention with proper formatting"
-  value       = "@pagerduty-${replace(pagerduty_service.alerts.name, "/[\\[\\]\\(\\) ]/", "")}"
+  value       = "@pagerduty-${replace(pagerduty_service.prod.name, "/[\\[\\]\\(\\) ]/", "")}"
 }
 
 output "alerts_service_id" {
-  description = "PagerDuty service ID for alerts"
-  value       = pagerduty_service.alerts.id
+  description = "PagerDuty service ID for prod alerts"
+  value       = pagerduty_service.prod.id
 }
 
 output "alerts_service_name" {
-  description = "PagerDuty service name for alerts"
-  value       = pagerduty_service.alerts.name
+  description = "PagerDuty service name for prod alerts"
+  value       = pagerduty_service.prod.name
 }
 
 output "critical_datadog_integration_key" {
@@ -38,40 +38,40 @@ output "critical_service_name" {
   value       = pagerduty_service.critical.name
 }
 
-output "notifications_datadog_integration_key" {
-  description = "PagerDuty Datadog Integration for notifications"
-  value       = pagerduty_service_integration.notifications.integration_key
+output "nonprod_datadog_integration_key" {
+  description = "PagerDuty Datadog Integration for nonprod"
+  value       = pagerduty_service_integration.nonprod.integration_key
 }
 
 output "notification_datadog_mention" {
   description = "PagerDuty Service Mention with proper formatting"
-  value       = "@pagerduty-${replace(pagerduty_service.notifications.name, "/[\\[\\]\\(\\) ]/", "")}"
+  value       = "@pagerduty-${replace(pagerduty_service.nonprod.name, "/[\\[\\]\\(\\) ]/", "")}"
 }
 
-output "notifications_service_id" {
-  description = "PagerDuty service ID for notifications"
-  value       = pagerduty_service.notifications.id
+output "nonprod_service_id" {
+  description = "PagerDuty service ID for non-prod alerts"
+  value       = pagerduty_service.nonprod.id
 }
 
-output "notifications_service_name" {
-  description = "PagerDuty service name for notifications"
-  value       = pagerduty_service.notifications.name
+output "nonprod_service_name" {
+  description = "PagerDuty service name for non-prod alerts"
+  value       = pagerduty_service.nonprod.name
 }
 
 output "datadog_integrations" {
   description = "All PagerDuty Datadog integrations"
   value = {
     "alerts" = {
-      "name" = pagerduty_service.alerts.name
-      "key"  = pagerduty_service_integration.alerts.integration_key
+      "name" = pagerduty_service.prod.name
+      "key"  = pagerduty_service_integration.prod.integration_key
     }
     "critical" = {
       "name" = pagerduty_service.critical.name
       "key"  = pagerduty_service_integration.critical.integration_key
     }
-    "notifications" = {
-      "name" = pagerduty_service.notifications.name
-      "key"  = pagerduty_service_integration.notifications.integration_key
+    "nonprod" = {
+      "name" = pagerduty_service.nonprod.name
+      "key"  = pagerduty_service_integration.nonprod.integration_key
     }
   }
 }
@@ -79,8 +79,8 @@ output "datadog_integrations" {
 output "pagerduty_services" {
   description = "All PagerDuty services"
   value = [
-    pagerduty_service.alerts.id,
+    pagerduty_service.prod.id,
     pagerduty_service.critical.id,
-    pagerduty_service.notifications.id
+    pagerduty_service.nonprod.id
   ]
 }

--- a/prod.tf
+++ b/prod.tf
@@ -1,5 +1,5 @@
-resource "pagerduty_service" "alerts" {
-  name                    = "${var.workload_name} Alerts (${var.customer_name})"
+resource "pagerduty_service" "prod" {
+  name                    = "${var.workload_name} Alerts - Prod 12x5 (${var.customer_name})"
   acknowledgement_timeout = 7200
   alert_creation          = "create_alerts_and_incidents"
   auto_resolve_timeout    = 86400
@@ -23,7 +23,7 @@ resource "pagerduty_service" "alerts" {
     type         = "fixed_time_per_day"
     time_zone    = "America/New_York"
     start_time   = "07:00:00"
-    end_time     = "20:00:00"
+    end_time     = "19:00:00"
     days_of_week = [1, 2, 3, 4, 5]
   }
 
@@ -38,23 +38,23 @@ resource "pagerduty_service" "alerts" {
   }
 }
 
-resource "pagerduty_service_dependency" "alerts" {
+resource "pagerduty_service_dependency" "prod" {
   dependency {
     dependent_service {
       id   = pagerduty_business_service.workload.id
       type = pagerduty_business_service.workload.type
     }
     supporting_service {
-      id   = pagerduty_service.alerts.id
-      type = pagerduty_service.alerts.type
+      id   = pagerduty_service.prod.id
+      type = pagerduty_service.prod.type
     }
   }
 }
 
-resource "pagerduty_slack_connection" "alerts" {
-  channel_id        = var.slack_engineering_alerts_channel
+resource "pagerduty_slack_connection" "prod" {
+  channel_id        = var.slack_engineering_prod_channel
   notification_type = "responder"
-  source_id         = pagerduty_service.alerts.id
+  source_id         = pagerduty_service.prod.id
   source_type       = "service_reference"
   workspace_id      = var.slack_workspace_id
 
@@ -77,15 +77,15 @@ resource "pagerduty_slack_connection" "alerts" {
   }
 }
 
-resource "pagerduty_service_integration" "alerts" {
+resource "pagerduty_service_integration" "prod" {
   name    = data.pagerduty_vendor.datadog.name
-  service = pagerduty_service.alerts.id
+  service = pagerduty_service.prod.id
   vendor  = data.pagerduty_vendor.datadog.id
 }
 
-resource "pagerduty_extension" "alerts" {
-  name              = "jira-${pagerduty_service.alerts.id}"
+resource "pagerduty_extension" "prod" {
+  name              = "jira-${pagerduty_service.prod.id}"
   config            = templatefile("${path.module}/jira.json", {})
-  extension_objects = [pagerduty_service.alerts.id]
+  extension_objects = [pagerduty_service.prod.id]
   extension_schema  = data.pagerduty_extension_schema.jira.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "customer_name" {
 }
 
 variable "slack_engineering_nonprod_channel" {
-  description = "The Slack channel ID for nonprod engineering alerts"
+  description = "The Slack channel ID for non-prod engineering alerts"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,18 +3,18 @@ variable "customer_name" {
   type        = string
 }
 
-variable "slack_engineering_notifications_channel" {
-  description = "The Slack channel ID for engineering notifications"
+variable "slack_engineering_nonprod_channel" {
+  description = "The Slack channel ID for nonprod engineering alerts"
   type        = string
 }
 
-variable "slack_engineering_alerts_channel" {
-  description = "The Slack channel ID for engineering alerts"
+variable "slack_engineering_prod_channel" {
+  description = "The Slack channel ID for prod engineering alerts"
   type        = string
 }
 
-variable "slack_engineering_critical_alerts_channel" {
-  description = "The Slack channel ID for engineering critical alerts"
+variable "slack_engineering_critical_channel" {
+  description = "The Slack channel ID for critical engineering alerts"
   type        = string
 }
 


### PR DESCRIPTION
Old names didn't match the naming model we were hoping to use. Renamed everything to make more sense going forward.